### PR TITLE
Implement Atspi::Accessible#get_text override

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,13 +30,19 @@ jobs:
           sudo apt-get update
           # Provides libgirepository-1.0.so.1
           sudo apt-get install libgirepository-1.0-1
+          # Provides Gtk-3.0.typelib
+          sudo apt-get install gir1.2-gtk-3.0
           # Provides Atspi-2.0.typelib
           sudo apt-get install gir1.2-atspi-2.0
+          # Needed to provide A11y dbus service used by Atspi
+          sudo apt-get install at-spi2-core
+          # Provides xvfb-run
+          sudo apt-get install xvfb
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run the default task
-        run: bundle exec rake
+      - name: Run the default task in a dbus and xvfb session
+        run: xvfb-run dbus-run-session bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gemspec
 gem "rake", "~> 13.0"
 gem "rake-manifest", "~> 0.2.0"
 
+gem "aruba", "~> 2.3"
+gem "gir_ffi-gtk", "~> 0.18.0"
 gem "minitest", "~> 5.16"
 
 gem "rubocop", "~> 1.73"

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,4 +1,5 @@
 lib/gir_ffi-atspi.rb
+lib/gir_ffi-atspi/accessible.rb
 lib/gir_ffi-atspi/version.rb
 README.md
 COPYING.LIB

--- a/lib/gir_ffi-atspi.rb
+++ b/lib/gir_ffi-atspi.rb
@@ -4,3 +4,5 @@ require_relative "gir_ffi-atspi/version"
 require "gir_ffi"
 
 GirFFI.setup :Atspi
+
+require_relative "gir_ffi-atspi/accessible"

--- a/lib/gir_ffi-atspi/accessible.rb
+++ b/lib/gir_ffi-atspi/accessible.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Atspi.load_class :Text
+Atspi::Text.setup_instance_method(:get_text)
+
+module GirFFIAtspi
+  # Overrides for AtspiAccessible methods
+  module AccessibleOverrides
+    def get_text(start_offset, end_offset)
+      Atspi::Text.instance_method(:get_text).bind_call(self, start_offset, end_offset)
+    end
+  end
+end
+
+Atspi.load_class :Accessible
+Atspi::Accessible.prepend GirFFIAtspi::AccessibleOverrides

--- a/test/fixtures/simple_gui.rb
+++ b/test/fixtures/simple_gui.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "gir_ffi-gtk3"
+
+Gtk.init
+
+class Application
+  def initialize
+    setup_gui
+    connect_signals
+    @win.show_all
+  end
+
+  def run
+    Gtk.main
+  end
+
+  private
+
+  def connect_signals
+    connect_click_signal
+    connect_destroy_signal
+  end
+
+  def connect_destroy_signal
+    @win.signal_connect("destroy") { Gtk.main_quit }
+  end
+
+  def connect_click_signal
+    @button.signal_connect("clicked") { @win.destroy }
+  end
+
+  def setup_gui
+    @win = Gtk::Window.new :toplevel
+    @box = Gtk::Box.new :vertical, 0
+    @box.add Gtk::Label.new "Hello, World!"
+    @button = Gtk::Button.new_with_label "Close"
+    @box.add @button
+    @win.add @box
+  end
+end
+
+Application.new.run

--- a/test/gir_ffi-atspi/accessible_test.rb
+++ b/test/gir_ffi-atspi/accessible_test.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "aruba/api"
 
 describe Atspi::Accessible do
   include Aruba::Api
+  include EndToEndTestHelpers
 
   describe "#get_text" do
     it "accepts two arguments" do
@@ -21,15 +21,7 @@ describe Atspi::Accessible do
       gui_app = File.expand_path("../fixtures/simple_gui.rb", __dir__)
       app_process = run_command "ruby #{gui_app}"
 
-      desktop = Atspi.get_desktop 0
-      app = nil
-      4.times do
-        desktop.child_count.times.reverse_each do |i|
-          child = desktop.get_child_at_index(i)
-          break app = child if child.name == "simple_gui.rb"
-        end
-        break if app
-      end
+      app = find_app("simple_gui.rb")
 
       frame = app.child_at_index(0)
       box = frame.child_at_index(1)

--- a/test/gir_ffi-atspi/accessible_test.rb
+++ b/test/gir_ffi-atspi/accessible_test.rb
@@ -4,10 +4,13 @@ require "test_helper"
 
 describe Atspi::Accessible do
   describe "#get_text" do
-    it "gets text and not the text interface" do
-      skip "Implement this next"
+    it "accepts two arguments" do
       obj = Atspi::Accessible.new
-      _(obj.get_text(0, -1)).must_equal ""
+
+      # NOTE: Without implementation, this would raise an ArgumentError instead
+      # TODO: Test this with a more positive case where there is an actual result
+      _(proc { obj.get_text(0, -1) })
+        .must_raise(GirFFI::GLibError, "The application no longer exists")
     end
   end
 end

--- a/test/gir_ffi-atspi/accessible_test.rb
+++ b/test/gir_ffi-atspi/accessible_test.rb
@@ -23,11 +23,12 @@ describe Atspi::Accessible do
 
       desktop = Atspi.get_desktop 0
       app = nil
-      until app
+      4.times do
         desktop.child_count.times.reverse_each do |i|
           child = desktop.get_child_at_index(i)
           break app = child if child.name == "simple_gui.rb"
         end
+        break if app
       end
 
       frame = app.child_at_index(0)

--- a/test/gir_ffi-atspi/accessible_test.rb
+++ b/test/gir_ffi-atspi/accessible_test.rb
@@ -1,16 +1,45 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "aruba/api"
 
 describe Atspi::Accessible do
+  include Aruba::Api
+
   describe "#get_text" do
     it "accepts two arguments" do
       obj = Atspi::Accessible.new
 
       # NOTE: Without implementation, this would raise an ArgumentError instead
-      # TODO: Test this with a more positive case where there is an actual result
       _(proc { obj.get_text(0, -1) })
         .must_raise(GirFFI::GLibError, "The application no longer exists")
+    end
+
+    it "fetches text in a running application" do
+      setup_aruba
+
+      gui_app = File.expand_path("../fixtures/simple_gui.rb", __dir__)
+      app_process = run_command "ruby #{gui_app}"
+
+      desktop = Atspi.get_desktop 0
+      app = nil
+      until app
+        desktop.child_count.times.reverse_each do |i|
+          child = desktop.get_child_at_index(i)
+          break app = child if child.name == "simple_gui.rb"
+        end
+      end
+
+      frame = app.child_at_index(0)
+      box = frame.child_at_index(1)
+
+      text = box.child_at_index(0)
+      _(text.get_text(0, -1)).must_equal("Hello, World!")
+
+      button = box.child_at_index(1)
+      button.do_action(0)
+    ensure
+      app_process.stop
     end
   end
 end

--- a/test/gir_ffi-atspi/accessible_test.rb
+++ b/test/gir_ffi-atspi/accessible_test.rb
@@ -24,7 +24,7 @@ describe Atspi::Accessible do
       app = find_app("simple_gui.rb")
 
       frame = app.child_at_index(0)
-      box = frame.child_at_index(1)
+      box = find_child_with_role(frame, :filler)
 
       text = box.child_at_index(0)
       _(text.get_text(0, -1)).must_equal("Hello, World!")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,4 +22,13 @@ module EndToEndTestHelpers
 
     app or raise "Application not found"
   end
+
+  def find_child_with_role(parent, role)
+    parent.child_count.times do |i|
+      child = parent.child_at_index(i)
+      return child if child.role == role
+    end
+
+    nil
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,20 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "gir_ffi-atspi"
 
 require "minitest/autorun"
+require "aruba/api"
+
+module EndToEndTestHelpers
+  def find_app(name)
+    desktop = Atspi.get_desktop 0
+    app = nil
+    4.times do
+      desktop.child_count.times.reverse_each do |i|
+        child = desktop.get_child_at_index(i)
+        break app = child if child.name == name
+      end
+      break if app
+    end
+
+    app or raise "Application not found"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,10 +7,12 @@ require "minitest/autorun"
 require "aruba/api"
 
 module EndToEndTestHelpers
-  def find_app(name)
+  def find_app(name) # rubocop:disable Metrics/MethodLength
     desktop = Atspi.get_desktop 0
     app = nil
-    4.times do
+
+    6.times do |try|
+      sleep try * 0.1
       desktop.child_count.times.reverse_each do |i|
         child = desktop.get_child_at_index(i)
         break app = child if child.name == name


### PR DESCRIPTION
- Ensure `Atspi::Accessible#get_text` delegates to `Atspi::Text#get_text`
- Test `Atspi::Accessible#get_text` in a real application
- Avoid infinite loop if test app doesn't start
- Extract `find_app` test helper method
- Run tests in a dbus and xvfb session in CI
- Give test app more time to boot in CI
- Make finding the correct widget in the test app more robust 