### PR TITLE
Update RuboCop configuration and fix new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,11 +3,9 @@ inherit_mode:
     - Exclude
 
 plugins:
-  - rubocop-performance
   - rubocop-minitest
-
-require:
   - rubocop-packaging
+  - rubocop-performance
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ gem "aruba", "~> 2.3"
 gem "gir_ffi-gtk", "~> 0.18.0"
 gem "minitest", "~> 5.16"
 
-gem "rubocop", "~> 1.73"
+gem "rubocop", "~> 1.76"
 gem "rubocop-minitest", "~> 0.38.0"
 gem "rubocop-packaging", "~> 0.6.0"
-gem "rubocop-performance", "~> 1.24"
+gem "rubocop-performance", "~> 1.25"
 
 gem "simplecov", "~> 0.22.0"

--- a/test/gir_ffi-atspi/accessible_test.rb
+++ b/test/gir_ffi-atspi/accessible_test.rb
@@ -27,6 +27,7 @@ describe Atspi::Accessible do
       box = find_child_with_role(frame, :filler)
 
       text = box.child_at_index(0)
+
       _(text.get_text(0, -1)).must_equal("Hello, World!")
 
       button = box.child_at_index(1)


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax for rubocop-packaging
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
