### PR TITLE
Remove scheduled CI runs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,13 +2,9 @@ name: Ruby
 
 "on":
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
-    branches:
-      - master
-  schedule:
-    - cron: '16 4 12 * *'
+    branches: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
These schedules make GitHub disable the whole workflow when activity is low, and I'd rather the jobs were run whenever a pull request lands.